### PR TITLE
chore: fix CLAUDE.md drift -- opt into AZ workflow + ADR 0219 alignment

### DIFF
--- a/.unleashed.json
+++ b/.unleashed.json
@@ -3,7 +3,7 @@
   "claude": {
     "effort": "max"
   },
-  "assemblyZero": false,
+  "assemblyZero": true,
   "onboard": {
     "auto": true,
     "pickupThresholdMinutes": 10,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,17 @@
-# CLAUDE.md - Sentinel
+# CLAUDE.md - sentinel Project
 
-**Workflow:** Full AssemblyZero workflow. Read `C:\Users\mcwiz\Projects\AssemblyZero\WORKFLOW.md`.
-
----
+You are a team member on the sentinel project, not a tool.
 
 ## Project Identifiers
 
 - **Repository:** `martymcenroe/sentinel`
+- **Project Root (Windows):** `C:\Users\mcwiz\Projects\sentinel`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/sentinel`
+- **Worktree Pattern:** `sentinel-{IssueID}` (e.g., `sentinel-22`)
 
----
+## Project-Specific Context
 
-## Project Overview
+**Stack:** Cloudflare Worker (JavaScript, ES Modules), entry point `src/index.js`. Tests via Vitest. Scripts in `scripts/` (bash). Deploy via `wrangler` (config in `wrangler.toml`).
 
 PR Issue-Reference Enforcer — GitHub App on Cloudflare Workers. Ensures every PR references a GitHub issue (`Closes #N`) or explicitly opts out (`No-Issue: <reason>`).
 
@@ -25,15 +26,13 @@ PR Issue-Reference Enforcer — GitHub App on Cloudflare Workers. Ensures every 
 ### Key Files
 
 - `wrangler.toml` — CF Worker config
-- `src/index.js` — Request router (/webhook, /health)
+- `src/index.js` — Request router (`/webhook`, `/health`)
 - `src/webhook.js` — HMAC signature verification + event dispatch
 - `src/auth.js` — GitHub App JWT signing + installation tokens
 - `src/checks.js` — Check Run creation via Checks API
 - `src/validate.js` — PR body regex validation
 
----
-
-## Development
+### Development
 
 ```bash
 npm test
@@ -45,3 +44,7 @@ npm run deploy
 - `WEBHOOK_SECRET` — GitHub webhook HMAC secret
 - `APP_ID` — GitHub App ID
 - `PRIVATE_KEY_B64` — PKCS#8 PEM private key, base64-encoded
+
+## Workflow Overrides
+
+_None yet. If this project needs to override any universal CLAUDE.md rule (e.g., a custom merge tool, a special test convention), document the override here with explicit language ("override") per ADR 0219._


### PR DESCRIPTION
## Summary

Resolves lint M6 + M9 by flipping ``.unleashed.json:assemblyZero=true`` (sentinel IS the fleet tooling that enforces AZ rules -- opting in on itself is consistent) and aligning CLAUDE.md with the lean ADR 0219 template.

## What changed

- ``.unleashed.json:assemblyZero`` -> ``true`` (was ``false``)
- Removed line-3 ``Read WORKFLOW.md`` instruction
- Added scaffolder-parity Project Identifiers + preamble + Workflow Overrides footer
- Preserved all sentinel-specific content (Architecture table, Key Files map, Development commands, Secrets block)

## Test plan

- [x] ``poetry run python tools/lint_per_repo_claude_md.py`` reports ``sentinel-22: PASS``, 50 lines, 0 findings
- [x] Key Files map preserved (wrangler.toml, src/index.js, webhook.js, auth.js, checks.js, validate.js)
- [x] Secrets block preserved (WEBHOOK_SECRET, APP_ID, PRIVATE_KEY_B64)

Closes #22

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)